### PR TITLE
Update Zettelkasten.jsx

### DIFF
--- a/RESOURCES/Datacore Components/Zettelkasten.jsx
+++ b/RESOURCES/Datacore Components/Zettelkasten.jsx
@@ -13,9 +13,6 @@ const Zettelkasten = () => {
         .sort(page => [page.$frontmatter.folgezettel], 'asc')
     );
 
-    // Fixed crash on entering letters/numbers into search if folgezettel property is 'number' type
-    // (that's the theory of why it happened to me)
-    // Also implements searching by folgezettel id as well
 const filteredPages = dc.useMemo(() => (
     allPages.filter(page => {
         if (filter == '') return true;

--- a/RESOURCES/Datacore Components/Zettelkasten.jsx
+++ b/RESOURCES/Datacore Components/Zettelkasten.jsx
@@ -13,13 +13,20 @@ const Zettelkasten = () => {
         .sort(page => [page.$frontmatter.folgezettel], 'asc')
     );
 
-    const filteredPages = dc.useMemo(() => (
-        allPages.filter(page => {
-            if (filter == '') return true;
-            return page.$name.toLowerCase().includes(filter.toLowerCase()) ||
-                page.$frontmatter.folgezettel.value.toLowerCase().includes(filter.toLowerCase());
-        })
-    ), [allPages, filter])
+    // Fixed crash on entering letters/numbers into search if folgezettel property is 'number' type
+    // (that's the theory of why it happened to me)
+    // Also implements searching by folgezettel id as well
+const filteredPages = dc.useMemo(() => (
+    allPages.filter(page => {
+        if (filter == '') return true;
+        const folgezettelValue = page.$frontmatter?.folgezettel?.value;
+        const folgezettelStr = typeof folgezettelValue === 'string' ? folgezettelValue : String(folgezettelValue);
+        return page.$name.toLowerCase().includes(filter.toLowerCase()) ||
+               folgezettelStr.toLowerCase().includes(filter.toLowerCase());
+    })
+), [allPages, filter]);
+
+
 
     const columns = [
         { id: '', value: (page) => page.$frontmatter?.folgezettel.value },


### PR DESCRIPTION
fixes input crash when entering a letter or a number, which threw the error `page.$frontmatter.folgezettel.value.toLowerCase is not a function`. not sure why it was happening. changes also implement searching for folgezettel ids.